### PR TITLE
commandt-like project completion

### DIFF
--- a/bash/completion_scripts/project_completion
+++ b/bash/completion_scripts/project_completion
@@ -7,7 +7,7 @@ class ProjectCompletion
   
   def matches
     projects.select do |task|
-      task[0, typed.length] == typed
+      task.match Regexp.new(typed.split('').join('.*'))
     end
   end
   


### PR DESCRIPTION
Hi Ryan,

how about this? 

The idea was to save some time when typing a long project name by typing only unique part of the project name. For instance, if you have 2 projects coolproject_one and coolproject_two, then it's possible to get into project two with "two<tab><tab>". 

Thanks,
Alex
