### PR TITLE
Enforce strict `.erb` filename matching

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,13 @@ task :install do
   Dir['*'].each do |file|
     next if %w[Rakefile README.rdoc LICENSE].include? file
     
-    if File.exist?(File.join(ENV['HOME'], ".#{file.sub('.erb', '')}"))
-      if File.identical? file, File.join(ENV['HOME'], ".#{file.sub('.erb', '')}")
-        puts "identical ~/.#{file.sub('.erb', '')}"
+    if File.exist?(File.join(ENV['HOME'], ".#{file.sub(/\.erb$/, '')}"))
+      if File.identical? file, File.join(ENV['HOME'], ".#{file.sub(/\.erb$/, '')}")
+        puts "identical ~/.#{file.sub(/\.erb$/, '')}"
       elsif replace_all
         replace_file(file)
       else
-        print "overwrite ~/.#{file.sub('.erb', '')}? [ynaq] "
+        print "overwrite ~/.#{file.sub(/\.erb$/, '')}? [ynaq] "
         case $stdin.gets.chomp
         when 'a'
           replace_all = true
@@ -23,7 +23,7 @@ task :install do
         when 'q'
           exit
         else
-          puts "skipping ~/.#{file.sub('.erb', '')}"
+          puts "skipping ~/.#{file.sub(/\.erb$/, '')}"
         end
       end
     else
@@ -33,14 +33,14 @@ task :install do
 end
 
 def replace_file(file)
-  system %Q{rm -rf "$HOME/.#{file.sub('.erb', '')}"}
+  system %Q{rm -rf "$HOME/.#{file.sub(/\.erb$/, '')}"}
   link_file(file)
 end
 
 def link_file(file)
-  if file =~ /.erb$/
-    puts "generating ~/.#{file.sub('.erb', '')}"
-    File.open(File.join(ENV['HOME'], ".#{file.sub('.erb', '')}"), 'w') do |new_file|
+  if file =~ /\.erb$/
+    puts "generating ~/.#{file.sub(/\.erb$/, '')}"
+    File.open(File.join(ENV['HOME'], ".#{file.sub(/\.erb$/, '')}"), 'w') do |new_file|
       new_file.write ERB.new(File.read(file)).result(binding)
     end
   else


### PR DESCRIPTION
It is possible that `.erb` occurs in the middle of a filename, e.g.:
`'gitconfig.erb.tmp'.sub('.erb', '') # => "gitconfig.tmp"`
Also, the `.` in the pattern `/.erb/` is a wildcard.
