### PR TITLE
Removed github API token from .gitconfig

### DIFF
--- a/gitconfig.erb
+++ b/gitconfig.erb
@@ -17,4 +17,3 @@
 	pretty = %C(yellow)%h%Creset %s %C(red)(%an, %cr)%Creset
 [github]
 	user = <%= print("GitHub Username: "); STDOUT.flush; STDIN.gets.chomp %>
-	token = <%= print("GitHub API Token: "); STDOUT.flush; STDIN.gets.chomp %>


### PR DESCRIPTION
I don't think the github API token is used anymore. 

http://stackoverflow.com/a/10418853/721141
