### PR TITLE
Don't install Readme.md

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :install do
   install_oh_my_zsh
   switch_to_zsh
   replace_all = false
-  files = Dir['*'] - %w[Rakefile README.rdoc LICENSE oh-my-zsh]
+  files = Dir['*'] - %w[Rakefile README.md LICENSE oh-my-zsh]
   files << "oh-my-zsh/custom/plugins/rbates"
   files << "oh-my-zsh/custom/rbates.zsh-theme"
   files.each do |file|


### PR DESCRIPTION
`rake install` tries to install all of the dot files in the repository that aren't support files. The README for the repository counts as a support file, but in commit b503f9fa4fd82457f1060e4cb3f3881c2e83eacd it was renamed from `README.rdoc` to `README.md` with the result that it currently gets installed.